### PR TITLE
Added setter of getCreator to stub the mspId of the transaction

### DIFF
--- a/src/ChaincodeMockStub.ts
+++ b/src/ChaincodeMockStub.ts
@@ -47,6 +47,7 @@ export class ChaincodeMockStub implements MockStub {
     public event: Map<string, Buffer> = new Map();
     private invokables: Map<string, MockStub>;
     private signedProposal: SignedProposal;
+    private mspId = 'dummymspId';
 
     /**
      * @param {string} name - Name of the mockstub
@@ -364,8 +365,18 @@ export class ChaincodeMockStub implements MockStub {
         return this.txTimestamp;
     }
 
+    /**
+     * Store a mspId of the transaction's creator
+     *
+     * @param {string} mspId
+     * @returns {void}
+     */
+    setCreator(mspId: string): void {
+        this.mspId = mspId;
+    }
+
     getCreator(): ProposalCreator {
-        return new ChaincodeProposalCreator('dummymspId', this.usercert);
+        return new ChaincodeProposalCreator(this.mspId, this.usercert);
     }
 
     /**

--- a/test/TestChaincode.ts
+++ b/test/TestChaincode.ts
@@ -151,7 +151,7 @@ export class TestChaincode {
 
         await stub.putState(args[0], Buffer.from(JSON.stringify(car)));
         await stub.setEvent('CREATE_CAR', 'Car created.');
-        
+
         console.info('============= END : Create Car ===========');
     }
 
@@ -200,5 +200,11 @@ export class TestChaincode {
 
         await stub.putState(args[0], Buffer.from(JSON.stringify(car)));
         console.info('============= END : changeCarOwner ===========');
+    }
+
+    async isRightMspId(stub, args) {
+        const transactionMspId = stub.getCreator().getMspid();
+
+        return transactionMspId === 'anotherMSPId';
     }
 };

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -180,4 +180,22 @@ describe('Test Mockstub', () => {
         expect(eventPayload).to.equal('Car created.');
     });
 
+    it('Should be able to set the mspId', async () => {
+
+        const stub = new ChaincodeMockStub('mock', chaincode);
+        // Set the right mspId
+        stub.setCreator('anotherMSPId');
+
+        const response: ChaincodeReponse = await stub.mockInvoke('test', ['isRightMspId']);
+        expect(response.status).to.eq(200);
+        expect(response.payload).to.equal(true);
+
+        // Set a bad mspId
+        stub.setCreator('aBadMSPId');
+
+        const response: ChaincodeReponse = await stub.mockInvoke('test', ['isRightMspId']);
+        expect(response.status).to.eq(200);
+        expect(response.payload).to.not.equal(true);
+    });
+
 });


### PR DESCRIPTION
Hi, `getCreator` could be used to manage permissions within a Chaincode, so `setCreator` could be useful to stub these permission.