### PR TITLE
Added a toBuffer() function onto the ChaincodeProposalCreator

### DIFF
--- a/src/ChaincodeProposalCreator.ts
+++ b/src/ChaincodeProposalCreator.ts
@@ -5,20 +5,22 @@ import { SerializedIdentity } from 'fabric-shim';
  */
 export class ChaincodeProposalCreator implements SerializedIdentity {
     // tslint:disable-next-line:variable-name
-    id_bytes: Buffer;
+    id_bytes: any;
 
     [fieldName: string]: any;
     mspid: string;
 
     constructor(private mspId: string, private signingId: string) {
-        this.id_bytes = Buffer.from(signingId);
+       this.id_bytes = Buffer.from(signingId);
+       // fabric-shim 1.3 makes a call to  toBuffer() in ClientIdentity constructor. We need to add this function to the id_bytes.
+       this.id_bytes.toBuffer = function() { return this; };
     }
 
     getMspid(): string {
         return this.mspId;
     }
 
-    getIdBytes(): Buffer {
+    getIdBytes(): any {
         return this.id_bytes;
     }
 }


### PR DESCRIPTION
fabric-shim 1.3 makes a call to  toBuffer() in ClientIdentity constructor and this was throwing the error detailed in https://github.com/wearetheledger/fabric-mock-stub/issues/17

This fix adds a function toBuffer() to the id_bytes, which prevents this error.

fabric-shim seems to do the same in their unit tests, have a look at function mockStub() in https://github.com/hyperledger/fabric-chaincode-node/blob/release-1.4/fabric-shim/test/unit/client-identity.js