### PR TITLE
fix: prevent args mutation

### DIFF
--- a/src/ChaincodeMockStub.ts
+++ b/src/ChaincodeMockStub.ts
@@ -106,12 +106,12 @@ export class ChaincodeMockStub implements MockStub, ChaincodeStub {
      */
     getFunctionAndParameters(): { params: string[]; fcn: string } {
 
-        const params = this.getStringArgs();
+        let params = this.getStringArgs();
         let fcn = '';
 
         if (params.length >= 1) {
             fcn = params[0];
-            params.splice(0, 1);
+            params = params.slice(1);
         }
 
         return {


### PR DESCRIPTION
Function getFunctionAndParameters is mutating the stub arguments, this is not what happens with the real stub args on a network.

close #29